### PR TITLE
Improve and clarify doc comments

### DIFF
--- a/lib/src/grouping.dart
+++ b/lib/src/grouping.dart
@@ -1,9 +1,15 @@
+/// Configuration for how digits are grouped in formatted numbers.
 abstract class Grouping {}
 
+/// Groups digits using a separator symbol at a fixed interval.
 class WithGrouping extends Grouping {
+  /// The number of digits per group.
   final int groupSize;
+
+  /// The symbol used to separate groups (e.g. ',' or ' ').
   final String groupingSymbol;
 
+  /// Creates a grouping with the given [groupSize] and [groupingSymbol].
   WithGrouping(this.groupSize, this.groupingSymbol);
 
   @override
@@ -23,6 +29,7 @@ class WithGrouping extends Grouping {
   int get hashCode => groupSize.hashCode ^ groupingSymbol.hashCode;
 }
 
+/// No digit grouping applied.
 class NoGrouping extends Grouping {
   @override
   bool operator ==(Object other) =>

--- a/lib/src/parsed_number_format.dart
+++ b/lib/src/parsed_number_format.dart
@@ -258,7 +258,7 @@ String _canonicalizedLocale(String? aLocale) {
     return aLocale;
   }
   var region = aLocale.substring(3);
-// If it's longer than three it's something odd, so don't touch it.
+  // If it's longer than three, it's something odd, so don't touch it.
   if (region.length <= 3) {
     region = region.toUpperCase();
   }
@@ -266,7 +266,7 @@ String _canonicalizedLocale(String? aLocale) {
   return '${aLocale[0]}${aLocale[1]}_$region';
 }
 
-/// Return the short version of a locale name, e.g. 'en_US' => 'en'
+/// Returns the short version of a locale name, e.g. 'en_US' => 'en'.
 String _shortLocale(String aLocale) {
   if (aLocale.length < 2) {
     return aLocale;

--- a/lib/src/parsed_number_format.dart
+++ b/lib/src/parsed_number_format.dart
@@ -6,10 +6,15 @@ import 'package:number_editing_controller/src/grouping.dart';
 import 'package:number_editing_controller/src/mask_parser_iterator.dart';
 import 'package:number_editing_controller/src/parts.dart';
 
+/// The result of formatting a [TextEditingValue] through [ParsedNumberFormat].
 class FormatResult {
+  /// The formatted text editing value.
   final TextEditingValue value;
+
+  /// The numeric value extracted from the input, or `null` if empty or invalid.
   final num? number;
 
+  /// Creates a [FormatResult] with the given [value] and [number].
   FormatResult(this.value, this.number);
 
   @override
@@ -29,7 +34,9 @@ class FormatResult {
   int get hashCode => value.hashCode ^ number.hashCode;
 }
 
+/// Parses and formats numbers according to locale-aware ICU number format patterns.
 class ParsedNumberFormat {
+  /// The ordered list of format parts that make up this number format.
   final List<NumberFormatPart> parts;
   final bool _allowNegative;
 

--- a/lib/src/part_length.dart
+++ b/lib/src/part_length.dart
@@ -1,20 +1,32 @@
+/// Describes the length constraints of a number format part.
 abstract class PartLength {}
 
+/// A fixed-length part.
 class DeterminedPartLength extends PartLength {
+  /// The exact length of this part.
   final int length;
 
+  /// Creates a fixed-length constraint of [length].
   DeterminedPartLength(this.length);
 }
 
+/// A variable-length part with minimum and maximum bounds.
 class VariablePartLength extends PartLength {
+  /// The minimum length of this part.
   final int min;
+
+  /// The maximum length of this part.
   final int max;
 
+  /// Creates a variable-length constraint between [min] and [max].
   VariablePartLength(this.min, this.max);
 }
 
+/// A part with a minimum length and no upper bound.
 class AtLeastPartLength extends PartLength {
+  /// The minimum length of this part.
   final int min;
 
+  /// Creates a minimum-length constraint of [min].
   AtLeastPartLength(this.min);
 }

--- a/lib/src/parts.dart
+++ b/lib/src/parts.dart
@@ -2,11 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:number_editing_controller/src/grouping.dart';
 import 'package:number_editing_controller/src/part_length.dart';
 
+/// The result of formatting a single [NumberFormatPart].
 class PartFormatResult {
+  /// The updated text editing value after formatting.
   final TextEditingValue value;
+
+  /// The number of characters consumed by this part.
   final int offset;
+
+  /// The numeric value extracted from this part, or `null` if none.
   final num? number;
 
+  /// Creates a [PartFormatResult] with the given [value], [offset], and [number].
   PartFormatResult(this.value, this.offset, this.number);
 
   @override
@@ -27,13 +34,18 @@ class PartFormatResult {
   int get hashCode => value.hashCode ^ offset.hashCode ^ number.hashCode;
 }
 
+/// A segment of a number format pattern that knows how to format its portion of input.
 abstract class NumberFormatPart {
+  /// The length constraints of this part.
   PartLength get length;
 
+  /// Formats the input [value] starting at [position] and returns the result.
   PartFormatResult format(TextEditingValue value, int position);
 }
 
+/// A part that represents static text (e.g. spaces or punctuation).
 class StaticPart extends NumberFormatPart {
+  /// The static text content.
   final String content;
 
   @override
@@ -72,14 +84,21 @@ class StaticPart extends NumberFormatPart {
   }
 }
 
+/// A [StaticPart] that represents a currency symbol.
 class CurrencySignPart extends StaticPart {
+  /// Creates a currency sign part with the given symbol [content].
   CurrencySignPart(super.content);
 }
 
+/// A part that represents the integer portion of a number.
 class RealPart extends NumberFormatPart {
+  /// The digit grouping configuration.
   final Grouping grouping;
+
+  /// Whether negative numbers are allowed.
   final bool allowNegative;
 
+  /// Creates a [RealPart] with the given [grouping] and [allowNegative] flag.
   RealPart(this.grouping, this.allowNegative);
 
   @override
@@ -171,11 +190,18 @@ class RealPart extends NumberFormatPart {
   int get hashCode => grouping.hashCode;
 }
 
+/// A part that represents the fractional/decimal portion of a number.
 class DecimalPart extends NumberFormatPart {
+  /// The minimum number of decimal digits.
   final int minLength;
+
+  /// The maximum number of decimal digits.
   final int maxLength;
+
+  /// The decimal separator symbol (e.g. '.' or ',').
   final String decimalSeparator;
 
+  /// Creates a [DecimalPart] with the given length bounds and [decimalSeparator].
   DecimalPart(this.minLength, this.maxLength, this.decimalSeparator);
 
   @override

--- a/lib/src/text_controller.dart
+++ b/lib/src/text_controller.dart
@@ -1,20 +1,30 @@
 import 'package:flutter/material.dart';
 import 'package:number_editing_controller/src/parsed_number_format.dart';
 
+/// A [TextEditingController] that automatically formats user input as
+/// numbers, decimals, or currencies with locale-aware formatting.
+///
+/// Use one of the named constructors to create an instance:
+/// - [NumberEditingTextController.currency] for currency amounts
+/// - [NumberEditingTextController.decimal] for decimal numbers
+/// - [NumberEditingTextController.integer] for integers
+///
+/// The formatted text is displayed in the [TextField], while the underlying
+/// numeric value can be accessed via the [number] property.
 class NumberEditingTextController extends TextEditingController {
   final ParsedNumberFormat _format;
 
   num? _number;
 
-  /// Creates a controller instance suitable for formatting input as a money amount
+  /// Creates a controller instance suitable for formatting input as a currency amount.
   ///
   /// [locale] - locale to be used for number formatting, defaults to [Intl.getCurrentLocale()]
-  /// [currencyName] - 3-symbol currency code (ex. USD, EUR, TRY)
-  /// [currencySymbol] - currency symbol (ex. $, €, ₺)
+  /// [currencyName] - 3-letter ISO 4217 currency code (e.g. USD, EUR, TRY)
+  /// [currencySymbol] - currency symbol (e.g. $, €, ₺)
   /// [value] - optional initial value
-  /// [decimalSeparator] - symbol used to separate decimal part
-  /// [groupSeparator] - symbol used to group number
-  /// [allowNegative] - allow negative number input
+  /// [decimalSeparator] - symbol used to separate the decimal part
+  /// [groupSeparator] - symbol used to group digits
+  /// [allowNegative] - whether to allow negative number input
   NumberEditingTextController.currency({
     String? locale,
     String? currencyName,
@@ -34,15 +44,15 @@ class NumberEditingTextController extends TextEditingController {
     number = value;
   }
 
-  /// Creates a controller instance suitable for formatting input as a decimal
+  /// Creates a controller instance suitable for formatting input as a decimal number.
   ///
   /// [locale] - locale to be used for number formatting, defaults to [Intl.getCurrentLocale()]
-  /// [minimalFractionDigits] - minimal fraction digits
-  /// [maximumFractionDigits] - maximal fraction digits
+  /// [minimalFractionDigits] - minimum number of fraction digits
+  /// [maximumFractionDigits] - maximum number of fraction digits
   /// [value] - optional initial value
-  /// [decimalSeparator] - symbol used to separate decimal part
-  /// [groupSeparator] - symbol used to group number
-  /// [allowNegative] - allow negative number input
+  /// [decimalSeparator] - symbol used to separate the decimal part
+  /// [groupSeparator] - symbol used to group digits
+  /// [allowNegative] - whether to allow negative number input
   NumberEditingTextController.decimal({
     String? locale,
     int? minimalFractionDigits,
@@ -62,12 +72,12 @@ class NumberEditingTextController extends TextEditingController {
     number = value;
   }
 
-  /// Creates a controller instance suitable for formatting input as an integer
+  /// Creates a controller instance suitable for formatting input as an integer.
   ///
   /// [locale] - locale to be used for number formatting, defaults to [Intl.getCurrentLocale()]
   /// [value] - optional initial value
-  /// [groupSeparator] - symbol used to group number
-  /// [allowNegative] - allow negative number input
+  /// [groupSeparator] - symbol used to group digits
+  /// [allowNegative] - whether to allow negative number input
   NumberEditingTextController.integer({
     String? locale,
     num? value,
@@ -81,10 +91,14 @@ class NumberEditingTextController extends TextEditingController {
     number = value;
   }
 
-  /// Extracts the underlying number value
+  /// The underlying numeric value extracted from the formatted text.
+  ///
+  /// Returns `null` when the text field is empty or contains no valid number.
   num? get number => _number;
 
-  /// Sets the underlying number value
+  /// Sets the numeric value and updates the displayed text with formatting.
+  ///
+  /// Setting to `null` clears the text field.
   set number(num? number) {
     _number = number;
     final text = number == null ? '' : _format.formatString(number);


### PR DESCRIPTION
Add class-level documentation to NumberEditingTextController and refine parameter descriptions. Fix minor grammar and punctuation in parsed_number_format comments.