### PR TITLE
Add library header and docs for controller file

### DIFF
--- a/lib/number_editing_controller.dart
+++ b/lib/number_editing_controller.dart
@@ -1,1 +1,5 @@
+/// A TextEditingController that formats numbers, decimals, and currencies
+/// as you type with locale support.
+library;
+
 export 'src/text_controller.dart' show NumberEditingTextController;


### PR DESCRIPTION
Add a top-level library directive and documentation comment. Export NumberEditingTextController from src/text_controller.dart.