### PR TITLE
Bump SDK constraints to Dart 3.3 and Flutter 3.19

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -225,4 +225,4 @@ packages:
     version: "14.3.0"
 sdks:
   dart: ">=3.9.0-0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.19.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ topics:
   - input
 
 environment:
-  sdk: ">=2.19.6 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Update example/pubspec.lock Flutter sdk entry