### PR TITLE
Simplify GitHub workflows and restrict triggers

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,16 +2,13 @@ name: Checks
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
 
 jobs:
-  build-push-deploy:
+  checks:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/publish-dry-run.yaml
+++ b/.github/workflows/publish-dry-run.yaml
@@ -7,25 +7,16 @@ on:
     branches: [ main ]
 
 jobs:
-  publish:
-
+  publish-dry-run:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
 
       - name: Configure flutter
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-
-      - name: Copy credentials
-        run: |
-          mkdir -p ~/Library/Application\ Support/dart
-          echo "${{ secrets.PUB_CREDENTIALS_JSON }}" >> ~/Library/Application\ Support/dart/pub-credentials.json
-          mkdir -p ~/.pub-cache
 
       - name: Pub get
         run: flutter pub get

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,21 +12,3 @@ jobs:
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     with:
       environment: pub.dev
-
-  flutter-publish:
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Configure flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-
-      - name: Pub get
-        run: flutter pub get
-
-      - name: Publish
-        run: flutter pub publish -f


### PR DESCRIPTION
Remove develop branch from workflow triggers and clean up jobs.

- Rename build-push-deploy to checks and publish to publish-dry-run
- Remove flutter publish job and the credentials-copy step
- Remove unused workflow permissions and extra steps